### PR TITLE
Fix build on linux by adding a missing #else

### DIFF
--- a/Sources/SwiftCommand/FileHandle+Async.swift
+++ b/Sources/SwiftCommand/FileHandle+Async.swift
@@ -11,6 +11,7 @@ fileprivate final actor IOActor {
             let read = Darwin.read
 #elseif canImport(Glibc)
             let read = Glibc.read
+#else
 #error("Unsupported platform!")
 #endif
             let amount = read(fd, buffer.baseAddress, buffer.count)


### PR DESCRIPTION
I really like your approach to this problem and hope you can continue it. I noticed however that with your last commit #b4ea08c1db90532e62e1d2ea44d1c7b630b45350 that you accidentally removed an #else causing the linux build to fail for no reason. 

Could you agree wit this simple fix? 