### PR TITLE
Make AsyncBytes and AsyncLineSequence not conflict with foundation variants when Darwin is available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,13 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-system", from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftCommand",
             dependencies: [
                 .product(name: "SystemPackage", package: "swift-system")
             ]
         ),
+        .executableTarget(name: "swift-command", dependencies: ["SwiftCommand"]),
         .testTarget(
             name: "SwiftCommandTests",
             dependencies: ["SwiftCommand"]

--- a/Package.swift
+++ b/Package.swift
@@ -6,17 +6,16 @@ import PackageDescription
 let package = Package(
     name: "SwiftCommand",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "SwiftCommand",
             targets: ["SwiftCommand"]),
+        .executable(name: "swift-command", targets: ["swift-command"])
+
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-system", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/SwiftCommand/AsyncLineSequence.swift
+++ b/Sources/SwiftCommand/AsyncLineSequence.swift
@@ -1,3 +1,7 @@
+
+#if canImport(Darwin)
+// Use Foundation.AsyncLineSequence
+#else
 /// A non-blocking sequence of newline-separated `String`s created by decoding
 /// the elements of `Base` as utf-8.
 public struct AsyncLineSequence<Base>: AsyncSequence
@@ -179,9 +183,11 @@ where Base: AsyncSequence, Base.Element == UInt8 {
 }
 
 extension AsyncSequence where Self.Element == UInt8 {
+
     /// A non-blocking sequence of newline-separated `String`s created by
     /// decoding the elements of `self` as utf-8.
     public var lines: AsyncLineSequence<Self> {
         AsyncLineSequence(_base: self)
     }
 }
+#endif

--- a/Sources/SwiftCommand/ChildProcess.swift
+++ b/Sources/SwiftCommand/ChildProcess.swift
@@ -163,7 +163,7 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
         public struct AsyncCharacters: AsyncSequence {
             @usableFromInline
             internal typealias Base =
-                AsyncCharacterSequence<FileHandle.CustomAsyncBytes>
+                AsyncCharacterSequence<AsyncBytes>
             
             /// The type of element produced by this asynchronous sequence.
             public typealias Element = Character
@@ -211,7 +211,7 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
         public struct AsyncLines: AsyncSequence {
             @usableFromInline
             internal typealias Base =
-                AsyncLineSequence<FileHandle.CustomAsyncBytes>
+                AsyncLineSequence<AsyncBytes>
             
             /// The type of element produced by this asynchronous sequence.
             public typealias Element = String

--- a/Sources/SwiftCommand/ChildProcess.swift
+++ b/Sources/SwiftCommand/ChildProcess.swift
@@ -163,7 +163,7 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
         public struct AsyncCharacters: AsyncSequence {
             @usableFromInline
             internal typealias Base =
-                AsyncCharacterSequence<AsyncBytes>
+            AsyncCharacterSequence<FileHandle.AsyncBytes>
             
             /// The type of element produced by this asynchronous sequence.
             public typealias Element = Character
@@ -211,7 +211,7 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
         public struct AsyncLines: AsyncSequence {
             @usableFromInline
             internal typealias Base =
-                AsyncLineSequence<AsyncBytes>
+                AsyncLineSequence<FileHandle.AsyncBytes>
             
             /// The type of element produced by this asynchronous sequence.
             public typealias Element = String

--- a/Sources/SwiftCommand/ExitStatus.swift
+++ b/Sources/SwiftCommand/ExitStatus.swift
@@ -1,6 +1,6 @@
 /// Describes the result of a child process after it has terminated.
 public struct ExitStatus: Equatable, Sendable {
-    private enum Status: Equatable, Sendable {
+    public enum Status: Equatable, Sendable {
         case success
 #if os(Windows)
         case terminatedBySignal
@@ -12,7 +12,7 @@ public struct ExitStatus: Equatable, Sendable {
 
     private let status: Status
 
-    private init(status: Status) {
+    public init(status: Status) {
         self.status = status
     }
 

--- a/Sources/SwiftCommand/ProcessOutput.swift
+++ b/Sources/SwiftCommand/ProcessOutput.swift
@@ -26,7 +26,7 @@ public struct ProcessOutput: Equatable, Sendable {
     /// process, if stderr was piped; `nil` otherwise.
     public let stderr: String?
 
-    internal init(
+    public init(
         status: ExitStatus,
         stdoutData: Data,
         stdout: String,

--- a/Sources/swift-command/main.swift
+++ b/Sources/swift-command/main.swift
@@ -1,0 +1,15 @@
+// Used to test the SwiftCommand public interface
+
+import Foundation
+import SwiftCommand
+
+// Echo the lines you input
+Task<Void, Swift.Error> {
+    let bytes: SwiftCommand.AsyncBytes = FileHandle.standardInput.bytes
+    for try await line in bytes.lines {
+        print("🎺 \(line)")
+    }
+}
+
+RunLoop.main.run()
+

--- a/Sources/swift-command/main.swift
+++ b/Sources/swift-command/main.swift
@@ -5,8 +5,8 @@ import SwiftCommand
 
 // Echo the lines you input
 Task<Void, Swift.Error> {
-    let bytes: SwiftCommand.AsyncBytes = FileHandle.standardInput.bytes
-    for try await line in bytes.lines {
+    let lines = FileHandle.standardInput.bytes.lines
+    for try await line in lines {
         print("🎺 \(line)")
     }
 }

--- a/Tests/SwiftCommandTests/SwiftCommandTests.swift
+++ b/Tests/SwiftCommandTests/SwiftCommandTests.swift
@@ -5,10 +5,7 @@ final class SwiftCommandTests: XCTestCase {
     static let lines = ["Foo", "Bar", "Baz", "Test1", "Test2"]
 
     func testEcho() async throws {
-        guard let command = Command.findInPath(withName: "echo") else {
-            fatalError()
-        }
-
+      let command = try Command.findInPath(withName: "echo")
         let process =
             try command.addArgument(Self.lines.joined(separator: "\n"))
                        .setStdout(.pipe)
@@ -25,13 +22,13 @@ final class SwiftCommandTests: XCTestCase {
 
     func testComposition() async throws {
         let echoProcess =
-            try Command.findInPath(withName: "echo")!
+            try Command.findInPath(withName: "echo")
                        .addArgument(Self.lines.joined(separator: "\n"))
                        .setStdout(.pipe)
                        .spawn()
         
         let grepProcess =
-            try Command.findInPath(withName: "grep")!
+            try Command.findInPath(withName: "grep")
                        .addArgument("Test")
                        .setStdin(.pipe(from: echoProcess.stdout))
                        .setStdout(.pipe)
@@ -50,7 +47,7 @@ final class SwiftCommandTests: XCTestCase {
     }
     
     func testStdin() async throws {
-        let process = try Command.findInPath(withName: "cat")!
+        let process = try Command.findInPath(withName: "cat")
                                  .setStdin(.pipe)
                                  .setStdout(.pipe)
                                  .spawn()
@@ -66,7 +63,7 @@ final class SwiftCommandTests: XCTestCase {
     }
     
     func testStderr() async throws {
-        let catCommand = Command.findInPath(withName: "cat")!
+        let catCommand = try Command.findInPath(withName: "cat")
 
         let output = try await catCommand.addArgument("non_existing.txt")
                                          .setStderr(.pipe)
@@ -86,7 +83,7 @@ final class SwiftCommandTests: XCTestCase {
     }
     
     func testParallelProcesses() async throws {
-        let command = Command.findInPath(withName: "cat")!
+        let command = try Command.findInPath(withName: "cat")
                              .setStdin(.pipe(closeImplicitly: false))
                              .setStdout(.pipe)
         
@@ -126,7 +123,7 @@ final class SwiftCommandTests: XCTestCase {
     }
     
     func testTermination() async throws {
-        let command = Command.findInPath(withName: "cat")!
+        let command = try Command.findInPath(withName: "cat")
                              .setStdin(.pipe(closeImplicitly: false))
                              .setStdout(.pipe)
         


### PR DESCRIPTION
When Darwin is available the implementation from Foundation is used.  

For the rest I tried to explain in the commit and/or commit description why I added things. Could you let me know if this would be something you would consider adding or how I can change it to be more like something to include in SwiftCommand.


I have been using `SwiftCommand` now for some time and it runs very smooth and I like working with it. Thanks for adding!