### PR TITLE
Remove `FileManager.isExecutableFile(atPath:)` check inside `Command(executablePath:)`

### DIFF
--- a/Sources/SwiftCommand/Command.swift
+++ b/Sources/SwiftCommand/Command.swift
@@ -61,18 +61,6 @@ import Foundation
 /// ```
 public struct Command<Stdin, Stdout, Stderr>: Equatable, Sendable
 where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
-    /// An error that can be thrown while initializing a command.
-    public enum Error: Swift.Error, CustomStringConvertible {
-        /// An error indicating that no executable exists at the given path.
-        case executableNotFound(path: FilePath)
-        
-        public var description: String {
-            switch self {
-            case let .executableNotFound(path):
-                return "There is no executable at path '\(path)'"
-            }
-        }
-    }
 
 
 #if os(Windows)

--- a/Sources/SwiftCommand/Command.swift
+++ b/Sources/SwiftCommand/Command.swift
@@ -173,17 +173,10 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
     /// - Parameters:
     ///   - executablePath: A `FilePath`, representing the program that should
     ///                     be executed when this command is spawned.
-    /// - Throws: An ``Command/Error``, if there is no file at `executablePath`,
-    ///           or if it isn't executable.
-    public init(executablePath: FilePath) throws
+    public init(executablePath: FilePath)
     where Stdin == UnspecifiedInputSource,
           Stdout == UnspecifiedOutputDestination,
           Stderr == UnspecifiedOutputDestination {
-        guard FileManager.default
-                         .isExecutableFile(atPath: executablePath.string) else {
-            throw Error.executableNotFound(path: executablePath)
-        }
-
         self.init(
             executablePath: executablePath,
             arguments: [],


### PR DESCRIPTION
Hello! I just started using your library here, and ran into an issue:

When trying to initialize a `Command` using the `Command(executablePath:)` initializer, the function first checks whether or not the provided executable path is executable or not, using `FileManager`'s `isExecutableFile(atPath:)` method.

Unfortunately, this seems to not always report consistent results. When I tried to use it, it told me that the script I was pointing at was not executable, which was incorrect.

Looking at [Apple's documentation on this method](https://developer.apple.com/documentation/foundation/filemanager/1414159-isexecutablefile), they actually recommend against using it this way:

> Attempting to predicate behavior based on the current state of the file system or a particular file on the file system is not recommended. Doing so can cause odd behavior or race conditions. It's far better to attempt an operation (such as loading a file or creating a directory), check for errors, and handle those errors gracefully than it is to try to figure out ahead of time whether the operation will succeed.

What do you think of removing the check from the initializer? If it's removed, you could also remove the `executableNotFound` Error, as this is the only place it's used.

## Testing

To test the issue initially, I created a simple Swift script that just runs the `isExecutableFile(atPath:)` method on the same file, and it actually reported back `true`. This led me to believe that it could be the issue Apple mentions here, "odd behavior or race condition".

I'm not sure if there is a reasonable way to test this in unit tests, as the behavior seems inconsistent, but let me know if you have ideas. I'd be happy to write a test for this.