### PR TITLE
Make it build with swift build --swift-sdk x86_64-swift-linux-musl

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms",
       "state" : {
-        "revision" : "da4e36f86544cdf733a40d59b3a2267e3a7bbf36",
-        "version" : "1.0.0"
+        "revision" : "6ae9a051f76b81cc668305ceed5b0e0a7fd93d20",
+        "version" : "1.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
-        "version" : "1.2.1"
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
       }
     }
   ],

--- a/Sources/SwiftCommand/ChildProcess.swift
+++ b/Sources/SwiftCommand/ChildProcess.swift
@@ -5,6 +5,18 @@ import Foundation
 import WinSDK
 #endif
 
+#if os(macOS) || os(iOS)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
+#else
+#error("Unknown platform")
+#endif
+
 /// Handle to a running or exited child process
 ///
 /// This class is used to represent and manage child processes. A child process
@@ -721,6 +733,8 @@ where Stdin: InputSource, Stdout: OutputDestination, Stderr: OutputDestination {
             Darwin.kill(self.process.processIdentifier, SIGKILL)
             #elseif canImport(Glibc)
             Glibc.kill(self.process.processIdentifier, SIGKILL)
+            #elseif canImport(Musl)
+            Musl.kill(self.process.processIdentifier, SIGKILL)
             #else
             #error("Unsupported platform!")
             #endif

--- a/Sources/SwiftCommand/FileHandle+Async.swift
+++ b/Sources/SwiftCommand/FileHandle+Async.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+#if os(macOS) || os(iOS)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
+#else
+#error("Unknown platform")
+#endif
+
 fileprivate final actor IOActor {
 #if !os(Windows)
     fileprivate func read(
@@ -11,6 +23,10 @@ fileprivate final actor IOActor {
             let read = Darwin.read
 #elseif canImport(Glibc)
             let read = Glibc.read
+#elseif canImport(Musl)
+            let read = Musl.read
+#elseif os(Windows)
+            let read = ucrt.read
 #else
 #error("Unsupported platform!")
 #endif


### PR DESCRIPTION
Followed instructions at https://www.swift.org/documentation/articles/static-linux-getting-started.html

This will make it possible to build static linux libs without dependency on swift